### PR TITLE
3択問題の集計ロジックの遅延を改修

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/gin-gonic/gin v1.6.3
 	github.com/line/line-bot-sdk-go v7.8.0+incompatible
 	github.com/prometheus/client_golang v1.9.0
+	golang.org/x/sync v0.0.0-20201207232520-09787c993a3a
 	google.golang.org/api v0.40.0
 	google.golang.org/genproto v0.0.0-20210222152913-aa3ee6e6a81c
 )

--- a/go.sum
+++ b/go.sum
@@ -510,6 +510,7 @@ golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20201207232520-09787c993a3a h1:DcqTD9SDLc+1P/r1EmRBwnVsrOwW+kk2vWf9n+1sGhs=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=


### PR DESCRIPTION
## Why
- 3択問題の集計ロジックの遅延しており、フロントエンドの描画に時間が発生している。
- 上記の改善するために並列処理の実装を行った。

## What
- 3択問題の集計ロジックの遅延を改修
### Feature
- lineのユーザネームの取得処理をキャッシュの実装追加
- 質問の結果集計を処理を並列化の実装追加
- 集計結果の文言を修正

### Refactoring
- none.

## QA
(※user idのマスクしています。)
- 今回の修正で1s以下となっている。
```
anitta@anitta-macbook-pro ~ % curl -X GET "http://localhost:8080/v1/user_score?title=Q1&title=Q2&title=Q3&title=Q4&title=Q5&title=Q6&title=Q7&title=Q8" | jq .
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   232  100   232    0     0    507      0 --:--:-- --:--:-- --:--:--   507
[
  {
    "user_id": "****",
    "name": "堀内陽",
    "score": 2
  },
  {
    "user_id": "****",
    "name": "新田了仁",
    "score": 4
  },
  {
    "user_id": "****",
    "name": "江口",
    "score": 4
  }
]
anitta@anitta-macbook-pro ~ %
```
- 従来は表示に4秒かかっていた
```
anitta@anitta-macbook-pro ~ % curl -X GET "http://localhost:8080/v1/user_score?title=Q1&title=Q2&title=Q3&title=Q4&title=Q5&title=Q6&title=Q7&title=Q8" | jq .
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   232  100   232    0     0     55      0  0:00:04  0:00:04 --:--:--    55
[
  {
    "user_id": "****",
    "name": "江口",
    "score": 4
  },
  {
    "user_id": "****",
    "name": "新田了仁",
    "score": 4
  },
  {
    "user_id": "****",
    "name": "堀内陽",
    "score": 2
  }
]
```
## Checklists


## Appendix

- None
